### PR TITLE
propose `import.meta.command`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,16 @@ Likewise, implementations should try their best to avoid adding new `import.meta
 
 The process for adding new items to this registry is to open a pull request. Registrations must include all three fields: Name, Description, and a link to a specifying document. The specifying document does not need to be a formal standard -- links to project documentation or even source code is sufficient so long as the semantics of the property are appropriately described. After one week, if there are no objections from WinterCG participants to the registration and at least one sign off on the PR, it can be added.
 
+Import meta keys should be defined alphabetically.
+
 |        Property       | Description | Link |
 | --------------------- | ----------- | ---- |
-| `import.meta.url`     | A module scripts base URL | https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties |
-| `import.meta.resolve` | Resolves a module specifier to a URL using the current module's URL as base. | https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties |
-| `import.meta.main`    | Returns whether the current module is the entry point to your program. | https://deno.land/manual@v1.36.4/runtime/import_meta_api#importmeta--api |
+| `import.meta.command` | **true** when the current module is the process entry point within the top-level execution context. May remain `undefined` in other modules. | https://deno.land/manual@v1.36.4/runtime/import_meta_api#importmeta--api |
+| `import.meta.dir`     | Alias of `import.meta.dirname` | https://bun.sh/docs/api/import-meta |
 | `import.meta.dirname` | Absolute file path of the folder containing the current module, with trailing slash. Like CommonJS `__dirname`. | [import-meta-path-helpers.md](./import-meta-path-helpers.md) |
-| `import.meta.filename` | Absolute file path of current module. Like CommonJS `__filename`. | [import-meta-path-helpers.md](./import-meta-path-helpers.md) |
-| `import.meta.dir`     | Absolute path to the directory containing the current file, e.g. /path/to/project. Equivalent to __dirname in CommonJS modules (and Node.js) | https://bun.sh/docs/api/import-meta |
 | `import.meta.file`    | The name of the current file, e.g. index.tsx | https://bun.sh/docs/api/import-meta |
+| `import.meta.filename` | Absolute file path of current module. Like CommonJS `__filename`. | [import-meta-path-helpers.md](./import-meta-path-helpers.md) |
+| `import.meta.main`    | Alias of `import.meta.command` | https://deno.land/manual@v1.36.4/runtime/import_meta_api#importmeta--api |
 | `import.meta.path`    | Absolute path to the current file, e.g. /path/to/project/index.tx. Equivalent to __filename in CommonJS modules (and Node.js) | https://bun.sh/docs/api/import-meta |
+| `import.meta.resolve` | Resolves a module specifier to a URL using the current module's URL as base. | https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties |
+| `import.meta.url`     | A module scripts base URL | https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties |

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Import meta keys should be defined alphabetically.
 
 |        Property       | Description | Link |
 | --------------------- | ----------- | ---- |
-| `import.meta.command` | **true** when the current module is the process entry point within the top-level execution context. May remain `undefined` in other modules. | https://deno.land/manual@v1.36.4/runtime/import_meta_api#importmeta--api |
+| `import.meta.command` | **true** when the current module is the process entry point within the top-level execution context, corresponding to a POSIX-style run-to-completion process execution model (along with the standard OS access assumptions of environment variables, a filesystem, etc. and specifically, not applicable for the browser). May remain `undefined` in other modules. | https://deno.land/manual@v1.36.4/runtime/import_meta_api#importmeta--api |
 | `import.meta.dir`     | Alias of `import.meta.dirname` | https://bun.sh/docs/api/import-meta |
 | `import.meta.dirname` | Absolute file path of the folder containing the current module, with trailing slash. Like CommonJS `__dirname`. | [import-meta-path-helpers.md](./import-meta-path-helpers.md) |
 | `import.meta.file`    | The name of the current file, e.g. index.tsx | https://bun.sh/docs/api/import-meta |


### PR DESCRIPTION
This is a proposal for a new `import.meta.command` key on import meta, exactly matching the definition of `import.meta.main`. NodeJS has had difficulty finding alignment on `import.meta.main` (see https://github.com/nodejs/node/issues/49440), primarily because of a lack of clarify as to what exactly it means.

The name `command` is used here to indicate that this is the module that defines the POSIX-style command behaviour. The description has been further clarified to note that this is specifically only set for a process execution as well as for the top-level execution context in that process - workers, custom realms, other loader registries pointing to the same URL etc etc are therefore excluded from matching this condition (where perhaps a direct `process.argv[1]` equality might.

This PR is created in conjunction with the Node.js PR to introduce the behaviour.