### PR TITLE
Added `import.meta.env` for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ The process for adding new items to this registry is to open a pull request. Reg
 | `import.meta.dir`     | Absolute path to the directory containing the current file, e.g. /path/to/project. Equivalent to __dirname in CommonJS modules (and Node.js) | https://bun.sh/docs/api/import-meta |
 | `import.meta.file`    | The name of the current file, e.g. index.tsx | https://bun.sh/docs/api/import-meta |
 | `import.meta.path`    | Absolute path to the current file, e.g. /path/to/project/index.tx. Equivalent to __filename in CommonJS modules (and Node.js) | https://bun.sh/docs/api/import-meta |
+| `import.meta.env`     | An object containing the environmenet variables as key:value | https://github.com/franciscop/import-meta-env |


### PR DESCRIPTION
See [relevant Github](https://github.com/franciscop/import-meta-env) for all of the details, but basically this proposal is for a single place where the Environment Variables are all already loaded from the environment:

```js
const myenv = import.meta.env.MY_VARIABLE;
```

If this is relevant, I can also add a polyfill and some test, so please let me know and I can add those!