### PR TITLE
feat: update Deno Docs link of `import.meta.main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The process for adding new items to this registry is to open a pull request. Reg
 | --------------------- | ----------- | ---- |
 | `import.meta.url`     | A module scripts base URL | https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties |
 | `import.meta.resolve` | Resolves a module specifier to a URL using the current module's URL as base. | https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties |
-| `import.meta.main`    | Returns whether the current module is the entry point to your program. | https://deno.land/manual@v1.36.4/runtime/import_meta_api#importmeta--api |
+| `import.meta.main`    | Returns whether the current module is the entry point to your program. | https://docs.deno.com/runtime/manual/runtime/import_meta_api/#import.meta.main |
 | `import.meta.dirname` | Absolute file path of the folder containing the current module, with trailing slash. Like CommonJS `__dirname`. | [import-meta-path-helpers.md](./import-meta-path-helpers.md) |
 | `import.meta.filename` | Absolute file path of current module. Like CommonJS `__filename`. | [import-meta-path-helpers.md](./import-meta-path-helpers.md) |
 | `import.meta.dir`     | Absolute path to the directory containing the current file, e.g. /path/to/project. Equivalent to __dirname in CommonJS modules (and Node.js) | https://bun.sh/docs/api/import-meta |


### PR DESCRIPTION
Deno Docs url is updated, so it has to be changed.