### PR TITLE
Document existing use of env property

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,27 @@ Likewise, implementations should try their best to avoid adding new `import.meta
 
 The process for adding new items to this registry is to open a pull request. Registrations must include all three fields: Name, Description, and a link to a specifying document. The specifying document does not need to be a formal standard -- links to project documentation or even source code is sufficient so long as the semantics of the property are appropriately described. After one week, if there are no objections from WinterCG participants to the registration and at least one sign off on the PR, it can be added.
 
-|        Property       | Description | Link |
-| --------------------- | ----------- | ---- |
-| `import.meta.url`     | A module scripts base URL | https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties |
-| `import.meta.resolve` | Resolves a module specifier to a URL using the current module's URL as base. | https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties |
-| `import.meta.main`    | Returns whether the current module is the entry point to your program. | https://deno.land/manual@v1.36.4/runtime/import_meta_api#importmeta--api |
-| `import.meta.dirname` | Absolute file path of the folder containing the current module, with trailing slash. Like CommonJS `__dirname`. | [import-meta-path-helpers.md](./import-meta-path-helpers.md) |
-| `import.meta.filename` | Absolute file path of current module. Like CommonJS `__filename`. | [import-meta-path-helpers.md](./import-meta-path-helpers.md) |
-| `import.meta.dir`     | Absolute path to the directory containing the current file, e.g. /path/to/project. Equivalent to __dirname in CommonJS modules (and Node.js) | https://bun.sh/docs/api/import-meta |
-| `import.meta.file`    | The name of the current file, e.g. index.tsx | https://bun.sh/docs/api/import-meta |
-| `import.meta.path`    | Absolute path to the current file, e.g. /path/to/project/index.tx. Equivalent to __filename in CommonJS modules (and Node.js) | https://bun.sh/docs/api/import-meta |
-| `import.meta.env`    | Environmental configuration as a dictionary object. Warning: Exact semantics currently vary between implementations. | https://bun.sh/docs/api/import-meta, https://vitejs.dev/guide/env-and-mode |
+|        Property       | Description | Status | Link |
+| --------------------- | ----------- | ------ | ---- |
+| `import.meta.url`     | A module scripts base URL | ✅ / 🚀 | https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties |
+| `import.meta.resolve` | Resolves a module specifier to a URL using the current module's URL as base. | ✅ / 🚀 | https://html.spec.whatwg.org/multipage/webappapis.html#hostgetimportmetaproperties |
+| `import.meta.main`    | Returns whether the current module is the entry point to your program. | ☑️ / ✒️ | https://deno.land/manual@v1.36.4/runtime/import_meta_api#importmeta--api |
+| `import.meta.dirname` | Absolute file path of the folder containing the current module, with trailing slash. Like CommonJS `__dirname`. | ☑️ / 🚀 | [import-meta-path-helpers.md](./import-meta-path-helpers.md) |
+| `import.meta.filename` | Absolute file path of current module. Like CommonJS `__filename`. | ☑️ / 🚀 | [import-meta-path-helpers.md](./import-meta-path-helpers.md) |
+| `import.meta.dir`     | Absolute path to the directory containing the current file, e.g. /path/to/project. Equivalent to __dirname in CommonJS modules (and Node.js) | ⚠️ / ✒️ | https://bun.sh/docs/api/import-meta |
+| `import.meta.file`    | The name of the current file, e.g. index.tsx | ⚠️ / ✒️ | https://bun.sh/docs/api/import-meta |
+| `import.meta.path`    | Absolute path to the current file, e.g. /path/to/project/index.tx. Equivalent to __filename in CommonJS modules (and Node.js) | ⚠️ / ✒️ | https://bun.sh/docs/api/import-meta |
+| `import.meta.env`    | Environmental configuration as a dictionary object. | ⚠️ / 🧪 | https://bun.sh/docs/api/import-meta, https://vitejs.dev/guide/env-and-mode |
+
+## Status Values
+
+Recommendation level:
+  * ✅ **Baseline Standard:** Code can generally expect this field to be present and runtimes should generally implement it.
+  * ☑️ **Optional Standard:** The field may be unavailable in certain environments. Code should handle the field's absence to be fully portable.
+  * ⚠️ **Runtime-specific:** The field should only be used when targeting a specific runtime. Different runtimes may expose inconsistent behavior for this field.
+  * 🛑 **Discouraged:** There's a better, more interoperable alternative to using this field that should be used instead.
+
+Stability level:
+  * 🚀 **Stable:** Field has a clear specification and tests to ensure interoperable behavior. Deviation from the specified behavior is likely a bug in a runtime.
+  * ✒️ **Draft:** Fields has some level of agreed-upon specification. Exact semantics are still stabilizing and some edges may not have clearly specified behavior. Future changes are still possible but the overall shape of the field is unlikely to change.
+  * 🧪 **Experimental:** The field is being explored by at least one runtime or tool. It may appear in stable versions of the tool. "Experimental" is relative to its adoption by a wider ecosystem.

--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ The process for adding new items to this registry is to open a pull request. Reg
 | `import.meta.dir`     | Absolute path to the directory containing the current file, e.g. /path/to/project. Equivalent to __dirname in CommonJS modules (and Node.js) | https://bun.sh/docs/api/import-meta |
 | `import.meta.file`    | The name of the current file, e.g. index.tsx | https://bun.sh/docs/api/import-meta |
 | `import.meta.path`    | Absolute path to the current file, e.g. /path/to/project/index.tx. Equivalent to __filename in CommonJS modules (and Node.js) | https://bun.sh/docs/api/import-meta |
+| `import.meta.env`    | Environmental configuration as a dictionary object. Warning: Exact semantics currently vary between implementations. | https://bun.sh/docs/api/import-meta, https://vitejs.dev/guide/env-and-mode |


### PR DESCRIPTION
Alternative to https://github.com/wintercg/import-meta-registry/pull/5 that focusses on documenting the status quo instead of suggesting a specific spec for the `env` field.

I'm explicitly not using "environment variables" in the description because in Vite it contains things like `.DEV`/`.PROD` which are booleans and very much _not_ environment variables. See also: semantics are currently inconsistent and not fully interoperable.

Happy to add a "please don't add unflagged in more places until semantics are specified", to me the "Warning" already implies that.